### PR TITLE
fix compile for newer versions of `num`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate num;
 extern crate rand;
 extern crate utils;
 
-use utils::{Epsilon, map_range};
+use utils::{map_range};
 use rand::{Rand, random};
 use std::cell::RefCell;
 use std::fmt::Debug;
@@ -49,7 +49,7 @@ pub fn gen_raw<F>() -> F where F: Float + FromPrimitive + Rand {
 /// Generated value will always be 0.0 <= value < 1.0.
 #[inline]
 pub fn gen<F>(n: F, randomness: f32) -> F
-where F: Epsilon + Float + Rand + FromPrimitive + Debug {
+where F: Float + Rand + FromPrimitive + Debug {
     let (zero, one): (F, F) = (F::zero(), F::one());
     assert!(n >= zero && n <= one, "Gaussian::gen : given `n` ({:?}) must \
             be a percentage between 0 and 1.", n);
@@ -73,7 +73,7 @@ where F: Epsilon + Float + Rand + FromPrimitive + Debug {
 /// Gen gaussian value mapped to a range.
 #[inline]
 pub fn gen_map<F>(n: F, randomness: f32, min_range: F, max_range: F) -> F
-where F: Epsilon + Float + Rand + FromPrimitive + Debug {
+where F: Float + Rand + FromPrimitive + Debug {
     let (zero, one): (F, F) = (F::zero(), F::one());
     let perc = map_range(n, min_range, max_range, zero, one);
     map_range(gen(perc, randomness), zero, one, min_range, max_range)


### PR DESCRIPTION
at some point `num::Float` added `epsilon()`, which means that this crate no
longer needs to pull it in from `util`.